### PR TITLE
Remove comments from ColorBox Component

### DIFF
--- a/src/ColorBox.js
+++ b/src/ColorBox.js
@@ -4,7 +4,7 @@ export default class ColorBox extends Component {
 
   render() {
     return (
-      <div className="color-box" style={{opacity: 2}}>   //Note: The style attribute accepts a JavaScript object with camelCased properties rather than a CSS string
+      <div className="color-box" style={{opacity: 2}}>
         {/* your conditional code here! */}
       </div>
     )


### PR DESCRIPTION
The commented note causes the test below to fail, which causes student confusion.

[index-test.js](https://github.com/learn-co-curriculum/react-dynamic-components-lab/blob/master/test/index-test.js) line 65
```
it('correctly reduces the opacity by 0.1 after first recursive call', () => {
    expect(box.childAt(0).prop('opacity')).to.equal(0.9) 
  })
```